### PR TITLE
feat: dual-origin build switch (CUSTOM_DOMAIN) for the apex cutover

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
-name: Deploy Next.js to GitHub Pages
+# Renamed from 'Deploy Next.js to GitHub Pages' so the fleet smoke engine's
+# workflow_run trigger (workflows: ['Deploy to GitHub Pages']) fires here too.
+name: Deploy to GitHub Pages
 
 on:
   push:
@@ -8,6 +10,15 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      custom_domain:
+        description:
+          "Custom-domain build switch (#727): set to technologymonastery.org to build for the
+          apex (basePath '', CNAME emitted). Leave empty for the default project-URL build.
+          LIVE cutover deploys remain gated by epic #726 step 4."
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -29,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Setup Pages
@@ -39,7 +50,15 @@ jobs:
         run: npm ci
 
       - name: Build Next.js site
+        env:
+          # Input (dispatch) > repo variable > default project-URL build.
+          CUSTOM_DOMAIN: ${{ inputs.custom_domain || vars.CUSTOM_DOMAIN || '' }}
         run: npm run build
+
+      - name: Emit origin files (sitemap origin + conditional CNAME)
+        env:
+          CUSTOM_DOMAIN: ${{ inputs.custom_domain || vars.CUSTOM_DOMAIN || '' }}
+        run: NODE_ENV=production node scripts/emit-origin-files.mjs
 
       - name: Add .nojekyll file
         run: touch ./out/.nojekyll
@@ -256,3 +275,46 @@ jobs:
             }
 
             core.info(`Created incident issue #${created.data.number}`);
+
+  # Switch-on build verification (#727): prove the custom-domain artifact is
+  # correct on every run WITHOUT deploying it. The real cutover deploy stays
+  # gated behind epic #726 step 4 (workflow 120).
+  verify-custom-domain-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with CUSTOM_DOMAIN=technologymonastery.org
+        env:
+          CUSTOM_DOMAIN: technologymonastery.org
+        run: npm run build
+
+      - name: Emit origin files
+        env:
+          CUSTOM_DOMAIN: technologymonastery.org
+        run: NODE_ENV=production node scripts/emit-origin-files.mjs
+
+      - name: Assert root-relative artifact + CNAME
+        run: |
+          set -euo pipefail
+          # Root-relative asset/link refs only - external URLs that merely
+          # contain the repo name (e.g. the footer's GitHub LICENSE link)
+          # are legitimate in both modes.
+          if grep -rlE '(href|src)="/FFC-EX-technologymonastery\.org/' out/ --include='*.html' | head -1 | grep -q .; then
+            echo "::error::Exported HTML still uses the project base path in custom-domain mode:"
+            grep -rlE '(href|src)="/FFC-EX-technologymonastery\.org/' out/ --include='*.html' | head -5
+            exit 1
+          fi
+          [ "$(cat out/CNAME)" = "technologymonastery.org" ] || { echo "::error::out/CNAME missing or wrong"; exit 1; }
+          grep -q "https://technologymonastery.org/" out/sitemap.xml || { echo "::error::sitemap origin not rewritten"; exit 1; }
+          echo "custom-domain artifact verified: no project-basePath refs, CNAME + sitemap correct"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
-import { basePath } from '@/lib/site-config';
+import { basePath, siteOrigin } from '@/lib/site-config';
 
 export const metadata: Metadata = {
   title: 'The Technology Monastery - Free Technology for Nonprofits',
@@ -11,11 +11,11 @@ export const metadata: Metadata = {
   authors: [{ name: 'The Technology Monastery' }],
   creator: 'The Technology Monastery',
   publisher: 'Free for Charity',
-  metadataBase: new URL('https://freeforcharity.github.io/FFC-EX-technologymonastery.org/'),
+  metadataBase: new URL(`${siteOrigin}/`),
   openGraph: {
     title: 'The Technology Monastery - Free Technology for Nonprofits',
     description: 'Empowering small nonprofits with free, customized technology solutions through our dedicated community of skilled professionals.',
-    url: 'https://freeforcharity.github.io/FFC-EX-technologymonastery.org/',
+    url: `${siteOrigin}/`,
     siteName: 'The Technology Monastery',
     locale: 'en_US',
     type: 'website',

--- a/lib/base-path.d.ts
+++ b/lib/base-path.d.ts
@@ -1,0 +1,3 @@
+export const basePath: string;
+export const siteOrigin: string;
+export const customDomain: string;

--- a/lib/base-path.js
+++ b/lib/base-path.js
@@ -1,0 +1,19 @@
+// Single source of truth for the site's origin + base path, shared by
+// next.config.js (CJS) and lib/site-config.ts (TS re-export).
+//
+// The CUSTOM_DOMAIN switch selects between the two deploy origins:
+//   unset  -> GitHub Pages project URL (today's default):
+//             basePath /FFC-EX-technologymonastery.org
+//   set    -> custom-domain build (cutover, #726): basePath '',
+//             origin https://<CUSTOM_DOMAIN>
+// Development always serves from the root.
+const repoBase = '/FFC-EX-technologymonastery.org';
+const customDomain = process.env.CUSTOM_DOMAIN || '';
+
+const isProd = process.env.NODE_ENV === 'production';
+const basePath = customDomain ? '' : isProd ? repoBase : '';
+const siteOrigin = customDomain
+  ? `https://${customDomain}`
+  : `https://freeforcharity.github.io${repoBase}`;
+
+module.exports = { basePath, siteOrigin, customDomain };

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -1,5 +1,5 @@
-// Single source of truth for the GitHub Pages project base path.
-// Must match basePath in next.config.js; empty in development, where
-// next dev serves from the domain root.
-export const basePath =
-  process.env.NODE_ENV === 'production' ? '/FFC-EX-technologymonastery.org' : '';
+// Single source of truth for the GitHub Pages base path + site origin.
+// Logic lives in base-path.js so next.config.js (CJS) shares it verbatim
+// (next.config.js cannot import this TS module). See base-path.js for the
+// CUSTOM_DOMAIN switch semantics (#727 / cutover epic #726).
+export { basePath, siteOrigin, customDomain } from './base-path.js';

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,9 @@
+const { basePath } = require('./lib/base-path.js');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  basePath: process.env.NODE_ENV === 'production' ? '/FFC-EX-technologymonastery.org' : '',
+  basePath,
   images: {
     unoptimized: true,
   },

--- a/scripts/emit-origin-files.mjs
+++ b/scripts/emit-origin-files.mjs
@@ -1,0 +1,27 @@
+// Post-build origin fixup (#727): makes the exported artifact honest about
+// the origin it will serve from.
+// - Rewrites out/sitemap.xml URLs to the active origin (the committed
+//   sitemap historically hardcoded the apex even for project-URL deploys).
+// - Emits out/CNAME only for custom-domain builds, so project-URL deploys
+//   never carry a domain claim.
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { basePath, siteOrigin, customDomain } from '../lib/base-path.js';
+
+const sitemapPath = 'out/sitemap.xml';
+if (existsSync(sitemapPath)) {
+  const sm = readFileSync(sitemapPath, 'utf8');
+  const rewritten = sm.replace(/https:\/\/[^<\s]*?(\/[^<\s]*)?(?=<\/loc>)/g, (full) => {
+    const path = full.replace(/^https:\/\/[^/]+/, '').replace(/^\/FFC-EX-technologymonastery\.org/, '');
+    return `${siteOrigin}${path}`;
+  });
+  writeFileSync(sitemapPath, rewritten);
+  console.log(`sitemap.xml origin -> ${siteOrigin}`);
+}
+
+if (customDomain) {
+  writeFileSync('out/CNAME', `${customDomain}\n`);
+  console.log(`CNAME emitted: ${customDomain}`);
+} else {
+  console.log('project-URL build: no CNAME emitted');
+}
+console.log(`basePath='${basePath}'`);


### PR DESCRIPTION
Implements FreeForCharity/FFC-Cloudflare-Automation#727 (hard prereq for the #726 live cutover):

- **One switch, two origins**: `CUSTOM_DOMAIN` unset → today's project-URL build byte-for-byte intent (basePath `/FFC-EX-technologymonastery.org`, no CNAME in artifact); set → basePath `''`, `out/CNAME`, sitemap + metadataBase + og:url on https://technologymonastery.org. Single source of truth in `lib/base-path.js` shared by next.config.js (CJS) and site-config.ts.
- **Sitemap origin honesty**: the committed sitemap hardcoded the apex even for project-URL deploys — the post-build emit step now rewrites it to the ACTIVE origin in both modes.
- **verify-custom-domain-build job**: builds switch-on on every run WITHOUT deploying; asserts zero root-relative project-basePath refs (external URLs containing the repo name, like the footer's GitHub LICENSE link, are exempt), correct CNAME, correct sitemap.
- Workflow renamed to 'Deploy to GitHub Pages' (fleet smoke engine's workflow_run trigger now fires here) + Node 20→24.
- Old #6 documented: no deeper root cause on record than the basePath mismatch this eliminates.

**Verified locally in both modes** (default: basePath refs present, no CNAME; switch-on: zero refs, CNAME + apex sitemap). No live deploy of the switch-on artifact until #726 step 4 (workflow 120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)