### PR TITLE
feat: committed public/CNAME is the custom-domain source of truth

### DIFF
--- a/lib/base-path.js
+++ b/lib/base-path.js
@@ -3,9 +3,9 @@
 //
 // The committed public/CNAME file is the custom-domain source of truth
 // (GitHub Pages standard — the binding, the artifact, and the build all key
-// off the same file). The CUSTOM_DOMAIN env var remains only as a fallback
-// for preview builds dispatched with the deploy workflow's custom_domain
-// input before the file lands.
+// off the same file). The CUSTOM_DOMAIN env var applies only in build
+// contexts where public/CNAME is absent (e.g. the deploy workflow's
+// custom_domain preview input on a branch without the file).
 //   no CNAME -> GitHub Pages project URL:
 //               basePath /FFC-EX-technologymonastery.org
 //   CNAME    -> custom-domain build (cutover, #726): basePath '',

--- a/lib/base-path.js
+++ b/lib/base-path.js
@@ -11,8 +11,11 @@
 //   CNAME    -> custom-domain build (cutover, #726): basePath '',
 //               origin https://<domain>
 // Development always serves from the root.
+// This file must stay CJS so next.config.js can load it.
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { existsSync, readFileSync } = require('node:fs');
 const { join } = require('node:path');
+/* eslint-enable @typescript-eslint/no-require-imports */
 
 const repoBase = '/FFC-EX-technologymonastery.org';
 const cnamePath = join(__dirname, '..', 'public', 'CNAME');

--- a/lib/base-path.js
+++ b/lib/base-path.js
@@ -1,14 +1,23 @@
 // Single source of truth for the site's origin + base path, shared by
 // next.config.js (CJS) and lib/site-config.ts (TS re-export).
 //
-// The CUSTOM_DOMAIN switch selects between the two deploy origins:
-//   unset  -> GitHub Pages project URL (today's default):
-//             basePath /FFC-EX-technologymonastery.org
-//   set    -> custom-domain build (cutover, #726): basePath '',
-//             origin https://<CUSTOM_DOMAIN>
+// The committed public/CNAME file is the custom-domain source of truth
+// (GitHub Pages standard — the binding, the artifact, and the build all key
+// off the same file). The CUSTOM_DOMAIN env var remains only as a fallback
+// for preview builds dispatched with the deploy workflow's custom_domain
+// input before the file lands.
+//   no CNAME -> GitHub Pages project URL:
+//               basePath /FFC-EX-technologymonastery.org
+//   CNAME    -> custom-domain build (cutover, #726): basePath '',
+//               origin https://<domain>
 // Development always serves from the root.
+const { existsSync, readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
 const repoBase = '/FFC-EX-technologymonastery.org';
-const customDomain = process.env.CUSTOM_DOMAIN || '';
+const cnamePath = join(__dirname, '..', 'public', 'CNAME');
+const fileCname = existsSync(cnamePath) ? readFileSync(cnamePath, 'utf8').trim() : '';
+const customDomain = fileCname || process.env.CUSTOM_DOMAIN || '';
 
 const isProd = process.env.NODE_ENV === 'production';
 const basePath = customDomain ? '' : isProd ? repoBase : '';

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+technologymonastery.org


### PR DESCRIPTION
## Summary

Per operator direction: the CNAME file should be a real committed file and the source of truth, matching the GitHub Pages standard (GitHub itself commits a CNAME file when a custom domain is set).

- Adds `public/CNAME` containing `technologymonastery.org`. Next.js copies `public/` into the export, so the artifact carries the same file — binding, artifact, and repo all agree.
- `lib/base-path.js` now reads the committed `public/CNAME` as the primary custom-domain signal; the `CUSTOM_DOMAIN` env var remains only as a fallback for preview builds dispatched via the deploy workflow's `custom_domain` input.
- `scripts/emit-origin-files.mjs` is unchanged: it re-emits `out/CNAME` from the same resolved value, so output is identical.

This clears the Post-Deploy Smoke `public/CNAME ↔ Pages binding` drift assertion (run 29717155883), which was failing only because the domain lived in a repo variable instead of the file. No smoke-engine change needed — the file check is enforcing the right invariant.

## Test plan

- CI: lint, tests, build, and the `verify-custom-domain-build` job (asserts no project-basePath refs in a custom-domain build).
- Post-merge: Deploy runs, then Post-Deploy Smoke should go fully green with `mode=apex`, no drift.

Part of epic FreeForCharity/FFC-Cloudflare-Automation#726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)