### PR TITLE
fix: serve /.well-known/security.txt (mirror dot-dir into the export)

### DIFF
--- a/scripts/emit-origin-files.mjs
+++ b/scripts/emit-origin-files.mjs
@@ -4,7 +4,10 @@
 //   sitemap historically hardcoded the apex even for project-URL deploys).
 // - Emits out/CNAME only for custom-domain builds, so project-URL deploys
 //   never carry a domain claim.
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+// - Mirrors public/.well-known into out/ — Next's static export skips
+//   dot-directories in public/, which 404'd the canonical RFC 9116
+//   security.txt location (#53).
+import { readFileSync, writeFileSync, existsSync, cpSync } from 'node:fs';
 import { basePath, siteOrigin, customDomain } from '../lib/base-path.js';
 
 const sitemapPath = 'out/sitemap.xml';
@@ -16,6 +19,11 @@ if (existsSync(sitemapPath)) {
   });
   writeFileSync(sitemapPath, rewritten);
   console.log(`sitemap.xml origin -> ${siteOrigin}`);
+}
+
+if (existsSync('public/.well-known')) {
+  cpSync('public/.well-known', 'out/.well-known', { recursive: true });
+  console.log('.well-known mirrored into out/');
 }
 
 if (customDomain) {


### PR DESCRIPTION
## Summary

`/.well-known/security.txt` 404s on the live site while `/security.txt` serves — Next's static export skips dot-directories in `public/`, so the canonical RFC 9116 location never reached the artifact (PR #54 shipped the file; freeforcharity.org's stack serves it, confirming this is an export quirk, not a Pages limitation). `emit-origin-files.mjs` (which already runs post-build in both the deploy and verify jobs) now mirrors `public/.well-known` into `out/`.

## Test plan

- CI build + verify-custom-domain-build run the emit script and will show `.well-known mirrored into out/`.
- Post-merge: `curl -I https://technologymonastery.org/.well-known/security.txt` → 200.

Part of #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)