### PR TITLE
fix(deploy): include hidden files in the Pages artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,9 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: "./out"
+          # Default false silently drops dot-entries (.well-known, .nojekyll)
+          # from the artifact — /.well-known/security.txt 404'd live (#53).
+          include-hidden-files: true
 
   # Deployment job
   deploy:


### PR DESCRIPTION
## Summary

Root cause of the persistent `/.well-known/security.txt` 404 (follow-up to #56): `actions/upload-pages-artifact@v5` defaults `include-hidden-files: false` and excludes `.[^/]*` from the tar — verified by downloading the deployed `github-pages` artifact: it contained `./security.txt` but neither `./.well-known/` nor `./.nojekyll`, even though the build log showed the emit script mirroring `.well-known` into `out/`. Setting the action's supported `include-hidden-files: true` input fixes packaging (`.git`/`.github` remain excluded by the action regardless).

## Test plan

- Post-merge deploy → `curl -I https://technologymonastery.org/.well-known/security.txt` → 200 (verified from the open internet).
- Artifact tar listing shows `./.well-known/security.txt` and `./.nojekyll`.

Part of #53. Fleet note: every FFC-EX repo on `upload-pages-artifact@v5` that ships `.well-known` will need the same input — flagged for the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)